### PR TITLE
Add GPS coordinates capture to damage form

### DIFF
--- a/public/report.html
+++ b/public/report.html
@@ -28,6 +28,14 @@
                 <input type="text" id="location" class="form-control" placeholder="وصف موقع الحادث">
             </div>
         </div>
+        <div class="row g-3 mb-3">
+            <div class="col-md-4">
+                <button type="button" id="getCoordsBtn" class="btn btn-outline-primary w-100">الحصول على الإحداثيات</button>
+            </div>
+            <div class="col-md-8">
+                <input type="text" id="coordinates" class="form-control" placeholder="الإحداثيات" readonly>
+            </div>
+        </div>
         <select id="categorySelect" class="form-select mb-3"></select>
         <div id="itemsList" class="mb-3"></div>
         <button id="addItemsBtn" class="btn btn-secondary mb-3" type="button">إضافة</button>

--- a/public/report.js
+++ b/public/report.js
@@ -137,6 +137,23 @@ function discardReport() {
     loadItems(document.getElementById('categorySelect').value);
 }
 
+function getCoords() {
+    if (!navigator.geolocation) {
+        alert('المتصفح لا يدعم تحديد الموقع');
+        return;
+    }
+    navigator.geolocation.getCurrentPosition(
+        (pos) => {
+            const lat = pos.coords.latitude.toFixed(6);
+            const lon = pos.coords.longitude.toFixed(6);
+            document.getElementById('coordinates').value = `${lat}, ${lon}`;
+        },
+        () => {
+            alert('فشل الحصول على الإحداثيات');
+        }
+    );
+}
+
 async function downloadPdf(id) {
     const res = await fetch(`/api/report/${id}`);
     const data = await res.json();
@@ -204,4 +221,5 @@ window.addEventListener('DOMContentLoaded', () => {
     document.getElementById('reportForm').addEventListener('submit', handleSubmit);
     document.getElementById('addItemsBtn').addEventListener('click', addItems);
     document.getElementById('discardBtn').addEventListener('click', discardReport);
+    document.getElementById('getCoordsBtn').addEventListener('click', getCoords);
 });


### PR DESCRIPTION
## Summary
- add coordinate capture button and read-only field
- implement `getCoords` to use device GPS

## Testing
- `npm test` *(fails: Error: no test specified)*
- `git push` *(fails: Authentication failed)*

------
https://chatgpt.com/codex/tasks/task_e_684834f48f4483259e62cd4640678e17